### PR TITLE
Support paths being passed to source configuration

### DIFF
--- a/assets/lib/commands/check.rb
+++ b/assets/lib/commands/check.rb
@@ -29,7 +29,10 @@ module Commands
         base: input['source']['base']
       )
 
-      if pull_request
+      return [] unless pull_request
+      return [pull_request] unless input['source'].key?('paths')
+
+      if repo.pull_request_matches_paths?(pull_request.id, input['source']['paths'])
         [pull_request]
       else
         []

--- a/assets/lib/repository.rb
+++ b/assets/lib/repository.rb
@@ -32,6 +32,16 @@ class Repository
     end
   end
 
+  def pull_request_matches_paths?(id, paths)
+    files = Octokit.pull_request_files(name, id)
+    files.map do |file|
+      if File.fnmatch(paths, file['filename'])
+        return true
+      end
+    end
+    false
+  end
+
   private
 
   def pulls_options(base: nil)


### PR DESCRIPTION
Allow PR jobs to only be triggered when relevant
parts of the repository have been changed.

This is an investigation into how easy or otherwise this will be to support. I have some further things to investigate...

This should also support ignore_paths config, to match 1:1 with git-resource. Also is globbing behaviour correct? Does it support a list of different globs?
I've only added paths support to check. What (if anything) needs to be done for in or out?
NB: I haven't written a concourse resource before, nor do I write Ruby very much.